### PR TITLE
Design/minor fixes

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -13,7 +13,7 @@ export default class Home extends Component {
         <Row className="text-center">
           <Col>
             <h1>Welcome to MixNJuice!</h1>
-            <p style={{ 'font-size': '0.8em' }}>
+            <p style={{ fontSize: '0.8em' }}>
               <Link to="#">Click here to customize your front page!</Link>
             </p>
           </Col>

--- a/src/pages/user/Recipes.js
+++ b/src/pages/user/Recipes.js
@@ -9,8 +9,10 @@ export default class UserRecipes extends Component {
 
     for (let i = 0; i < 20; i++) {
       listItems.push(
-        <tr>
-          <Link to="#">Recipe {i}</Link>
+        <tr key={i}>
+          <td>
+            <Link to="#">Recipe {i}</Link>
+          </td>
         </tr>
       );
     }
@@ -20,13 +22,13 @@ export default class UserRecipes extends Component {
         <Row>
           <Col>
             <h1>Your Original Recipes</h1>
-            <Table striped bordered hover>
+            <Table striped bordered>
               <tbody>{listItems}</tbody>
             </Table>
           </Col>
           <Col>
             <h1>Your Adapted Recipes</h1>
-            <Table striped bordered hover>
+            <Table striped bordered>
               <tbody>{listItems}</tbody>
             </Table>
           </Col>

--- a/src/style.scss
+++ b/src/style.scss
@@ -206,6 +206,11 @@ h1.recipeTitle {
   border: 1px solid $teal;
 }
 
+// Style for "striped" tables
+.table-striped tbody tr:nth-of-type(odd) {
+  background-color: $lightest-blue;
+}
+
 // Link animations in the header links
 // Credit to: https://emilkowalski.github.io/css-effects-snippets/
 .borderLeftRight {


### PR DESCRIPTION
https://github.com/gusta-project/frontend/commit/7efa162bb8324e638aa334b68e9030a4e3721089 React was throwing an error in the Chrome development panel because the list items weren't keyed. Even though this is a placeholder list, I gave them keys to get rid of the error.

Also removed the hover effect for the table cells.

https://github.com/gusta-project/frontend/commit/5917e928e2790dd7a378cc23ac467a41c8f6ad3e Small change to style.scss so that the striped tables fit with the color scheme. The default gray cells are now `$lightest-blue` instead.

https://github.com/gusta-project/frontend/commit/666cd8537b3e8315fd6db8f9ba745d09431990d5 React was throwing an error in the Chrome development panel  because it didn't like me using the standard CSS `"font-size"` object key for inline styling, so I changed it to `fontSize`. It made no visual difference, it just removed the error.