### PR TITLE
Fix App snapshot tests

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "esnext",
+    "module": "es5",
     "jsx": "react",
     "baseUrl": "./src"
   },

--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -6,18 +6,175 @@ import configureStore from 'redux-mock-store';
 import App from './App';
 import { withMemoryRouter } from 'utils';
 
-jest.mock('components/Header/Header');
-jest.mock('components/Home/NewRecipes');
-jest.mock('components/Home/FeaturedMixer');
-jest.mock('components/Home/TopRecipesDay');
+jest.mock('components/Header/Header', () =>
+  require('utils').mockComponent('Header')
+);
+jest.mock('pages/NotFound', () => require('utils').mockComponent('NotFound'));
+jest.mock('pages/Home', () => require('utils').mockComponent('Home'));
+jest.mock('pages/Login', () => require('utils').mockComponent('Login'));
+jest.mock('pages/Register', () => require('utils').mockComponent('Register'));
+jest.mock('pages/user/Profile', () =>
+  require('utils').mockComponent('Profile')
+);
+jest.mock('pages/user/Recipes', () =>
+  require('utils').mockComponent('Recipes')
+);
+jest.mock('pages/user/Favorites', () =>
+  require('utils').mockComponent('Favorites')
+);
+jest.mock('pages/user/FlavorStash', () =>
+  require('utils').mockComponent('FlavorStash')
+);
+jest.mock('pages/user/Settings', () =>
+  require('utils').mockComponent('Settings')
+);
+jest.mock('pages/user/ShoppingList', () =>
+  require('utils').mockComponent('ShoppingList')
+);
+jest.mock('pages/Calculator', () =>
+  require('utils').mockComponent('Calculator')
+);
+jest.mock('pages/Flavors', () => require('utils').mockComponent('Flavors'));
+jest.mock('pages/Recipe', () => require('utils').mockComponent('Recipe'));
 
 describe('<App />', () => {
   const initialState = {};
   const mockStore = configureStore();
   const store = mockStore(initialState);
 
-  it('renders correctly', () => {
+  it('renders home by default', () => {
     const RoutedApp = withMemoryRouter(App);
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders login page', () => {
+    const RoutedApp = withMemoryRouter(App, { initialEntries: ['/login'] });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders register page', () => {
+    const RoutedApp = withMemoryRouter(App, { initialEntries: ['/register'] });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders profile page', () => {
+    const RoutedApp = withMemoryRouter(App, { initialEntries: ['/profile'] });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders user recipes page', () => {
+    const RoutedApp = withMemoryRouter(App, {
+      initialEntries: ['/userRecipes']
+    });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders favorites page', () => {
+    const RoutedApp = withMemoryRouter(App, { initialEntries: ['/favorites'] });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders flavor stash page', () => {
+    const RoutedApp = withMemoryRouter(App, {
+      initialEntries: ['/flavorStash']
+    });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders user settings page', () => {
+    const RoutedApp = withMemoryRouter(App, {
+      initialEntries: ['/userSettings']
+    });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders shopping list page', () => {
+    const RoutedApp = withMemoryRouter(App, {
+      initialEntries: ['/shoppingList']
+    });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders calculator page', () => {
+    const RoutedApp = withMemoryRouter(App, {
+      initialEntries: ['/calculator']
+    });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders flavors page', () => {
+    const RoutedApp = withMemoryRouter(App, { initialEntries: ['/flavors'] });
+    const component = renderer.create(
+      <Provider store={store}>
+        <RoutedApp />
+      </Provider>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders recipe page', () => {
+    const RoutedApp = withMemoryRouter(App, { initialEntries: ['/recipe'] });
     const component = renderer.create(
       <Provider store={store}>
         <RoutedApp />

--- a/src/components/App/__snapshots__/App.test.js.snap
+++ b/src/components/App/__snapshots__/App.test.js.snap
@@ -1,35 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<App /> renders correctly 1`] = `
-<div
-  className="container"
->
-  <div
-    className="text-center row"
-  >
-    <div
-      className="col"
-    >
-      <h1>
-        Welcome to MixNJuice!
-      </h1>
-      <p
-        style={
-          Object {
-            "font-size": "0.8em",
-          }
-        }
-      >
-        <a
-          href="/"
-          onClick={[Function]}
-        >
-          Click here to customize your front page!
-        </a>
-      </p>
-    </div>
-  </div>
-  <hr />
-  <hr />
-</div>
+exports[`<App /> renders calculator page 1`] = `
+Array [
+  <Header />,
+  <Calculator />,
+]
+`;
+
+exports[`<App /> renders favorites page 1`] = `
+Array [
+  <Header />,
+  <Favorites />,
+]
+`;
+
+exports[`<App /> renders flavor stash page 1`] = `
+Array [
+  <Header />,
+  <FlavorStash />,
+]
+`;
+
+exports[`<App /> renders flavors page 1`] = `
+Array [
+  <Header />,
+  <Flavors />,
+]
+`;
+
+exports[`<App /> renders home by default 1`] = `
+Array [
+  <Header />,
+  <Home />,
+]
+`;
+
+exports[`<App /> renders login page 1`] = `
+Array [
+  <Header />,
+  <Login />,
+]
+`;
+
+exports[`<App /> renders profile page 1`] = `
+Array [
+  <Header />,
+  <Profile />,
+]
+`;
+
+exports[`<App /> renders recipe page 1`] = `
+Array [
+  <Header />,
+  <Recipe />,
+]
+`;
+
+exports[`<App /> renders register page 1`] = `
+Array [
+  <Header />,
+  <Register />,
+]
+`;
+
+exports[`<App /> renders shopping list page 1`] = `
+Array [
+  <Header />,
+  <ShoppingList />,
+]
+`;
+
+exports[`<App /> renders user recipes page 1`] = `
+Array [
+  <Header />,
+  <Recipes />,
+]
+`;
+
+exports[`<App /> renders user settings page 1`] = `
+Array [
+  <Header />,
+  <Settings />,
+]
 `;

--- a/src/pages/user/Recipes.js
+++ b/src/pages/user/Recipes.js
@@ -9,7 +9,7 @@ export default class UserRecipes extends Component {
 
     for (let i = 0; i < 20; i++) {
       listItems.push(
-        <tr>
+        <tr key={i}>
           <Link to="#">Recipe {i}</Link>
         </tr>
       );

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -27,17 +27,19 @@ export function buildActions(reducer, actions) {
  * @param {object} props An object containing props to setup
  * @return {object} Mock component with specified name and props
  */
-export function mockComponent(name, props = {}) {
-  return () => createElement(name, props, props.children);
-}
+export const mockComponent = (name, props = {}) => () =>
+  createElement(name, props, props.children);
 
 /**
  * Wraps a React component in a <MemoryRouter> suitable for testing
  *
  * @param {Component} WrappedComponent React component to wrap
  */
-export const withMemoryRouter = WrappedComponent => props => (
-  <MemoryRouter>
+export const withMemoryRouter = (
+  WrappedComponent,
+  routerProps = {}
+) => props => (
+  <MemoryRouter {...routerProps}>
     <WrappedComponent {...props} />
   </MemoryRouter>
 );


### PR DESCRIPTION
This PR makes the following changes:

* [Fixes](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/app-snapshots?expand=1#diff-9be4f8e03a4f3bffa2e1404410a10da7L3) an issue in VS Code where ctrl+clicking on an import statement that featured an implied `/index` suffix would not work
* [Correctly mock](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/app-snapshots?expand=1#diff-bcdfae44b3008ea7f86472927b8e67a3R9) all of the components that App can render
* [Add test cases](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/app-snapshots?expand=1#diff-bcdfae44b3008ea7f86472927b8e67a3R56) for all current pages
* [Updates App snapshots](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/app-snapshots?expand=1#diff-ae9770a6a65d1a9cda86aa5bd749f90bR6) with newly added test cases
* [Fix](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/app-snapshots?expand=1#diff-cd09a2a04a8dd82a85aa9a56816096c9R12) a React warning message because an iterable of DOM nodes lacked the `key` prop.
* [Modify](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/app-snapshots?expand=1#diff-8968c62593320351ced6a0ef776ef599R38) withMemoryRouter test helper to accept props that are passed to the `<MemoryRouter>`.