### PR TITLE
Minor fixes

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -13,7 +13,7 @@ export default class Home extends Component {
         <Row className="text-center">
           <Col>
             <h1>Welcome to MixNJuice!</h1>
-            <p style={{ 'font-size': '0.8em' }}>
+            <p style={{ fontSize: '0.8em' }}>
               <Link to="#">Click here to customize your front page!</Link>
             </p>
           </Col>

--- a/src/pages/__snapshots__/Home.test.js.snap
+++ b/src/pages/__snapshots__/Home.test.js.snap
@@ -16,7 +16,7 @@ exports[`<Home /> renders correctly 1`] = `
       <p
         style={
           Object {
-            "font-size": "0.8em",
+            "fontSize": "0.8em",
           }
         }
       >

--- a/src/pages/user/Recipes.js
+++ b/src/pages/user/Recipes.js
@@ -10,7 +10,9 @@ export default class UserRecipes extends Component {
     for (let i = 0; i < 20; i++) {
       listItems.push(
         <tr key={i}>
-          <Link to="#">Recipe {i}</Link>
+          <td>
+            <Link to="#">Recipe {i}</Link>
+          </td>
         </tr>
       );
     }

--- a/src/pages/user/Recipes.js
+++ b/src/pages/user/Recipes.js
@@ -22,13 +22,13 @@ export default class UserRecipes extends Component {
         <Row>
           <Col>
             <h1>Your Original Recipes</h1>
-            <Table striped bordered hover>
+            <Table striped bordered>
               <tbody>{listItems}</tbody>
             </Table>
           </Col>
           <Col>
             <h1>Your Adapted Recipes</h1>
-            <Table striped bordered hover>
+            <Table striped bordered>
               <tbody>{listItems}</tbody>
             </Table>
           </Col>

--- a/src/style.scss
+++ b/src/style.scss
@@ -148,7 +148,10 @@ a.active {
 
 // Changing the border of any form fields
 .form-control {
-  border: 1px solid #000;
+  border: 1px solid #000;// Style for "striped" tables
+  .table-striped tbody tr:nth-of-type(odd) {
+    background-color: $lightest-blue;
+  }
   outline: 0 none;
 }
 
@@ -204,6 +207,11 @@ h1.recipeTitle {
 
 .img-thumbnail {
   border: 1px solid $teal;
+}
+
+// Style for "striped" tables
+.table-striped tbody tr:nth-of-type(odd) {
+  background-color: $lightest-blue;
 }
 
 // Link animations in the header links


### PR DESCRIPTION
https://github.com/gusta-project/frontend/commit/993ee004b3aa84573d98a7c77330948ed9441d0f Recipes were put directly into a table row. Put them inside a cell inside the row.

https://github.com/gusta-project/frontend/commit/849ec2df7c73055d31ba1df7289ff8f33607751b Removed the hover effect for the table cells.

https://github.com/gusta-project/frontend/commit/f92b2903b40c090f16ebe3f91c8ecdac6212d739 Small change to style.scss so that the striped tables fit with the color scheme. The default gray cells are now `$lightest-blue` instead.

https://github.com/gusta-project/frontend/commit/ba5fcc1f153756b53183463841746b123d349757 React was throwing an error in the Chrome development panel because it didn't like me using the standard CSS `"font-size"` object key for inline styling, so I changed it to `fontSize`. It made no visual difference, it just removed the error.