### PR TITLE
Specify a real value in jsconfig.json for compiler module type

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "es5",
+    "module": "commonjs",
     "jsx": "react",
     "baseUrl": "./src"
   },


### PR DESCRIPTION
I had changed the compilerOptions module type in #13 to resolve an issue where using "go to defintion" on an import that had an implied `/index` on the module name would not work. In fixing the issue, I set the value to an invalid value. Instead, use `commonjs` which has working "go to definition" and also is a valid value.