### PR TITLE
Clean up Sass variable usage

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -94,7 +94,7 @@ hr {
 
 // Styling for dropdown links in the nav
 .dropdown-toggle {
-  color: #000 !important;
+  color: $black;
 }
 
 // Styling for the dropdown menu
@@ -126,8 +126,8 @@ a.active {
 .form-check-input {
   //-webkit-appearance: none;
   appearance: none;
-  background-color: #fff;
-  border: 1px solid #000;
+  background-color: $white;
+  border: 1px solid $black;
   width: 20px;
   height: 20px;
   border-radius: 0.3rem;
@@ -141,13 +141,14 @@ a.active {
 // Changing disabled buttons to grey
 .btn-primary.disabled,
 .btn-primary:disabled {
-  background-color: #777;
-  border-color: #333;
+  color: gray("800");
+  background-color: gray("300");
+  border-color: gray("800");
 }
 
 // Changing the border of any form fields
 .form-control {
-  border: 1px solid #000;// Style for "striped" tables
+  border: 1px solid $black; // Style for "striped" tables
   .table-striped tbody tr:nth-of-type(odd) {
     background-color: $lightest-blue;
   }
@@ -163,7 +164,7 @@ a.active {
 
 // Changing the background for the text next to an input field
 .input-group-text {
-  background-color: #eee;
+  background-color: gray("200");
 }
 
 // Changing the column width of the ingredient percent input
@@ -195,7 +196,7 @@ input {
 
 // Style for file inputs
 input[type="file"] {
-  border: 1px solid #000;
+  border: 1px solid $black;
   border-radius: 0.25rem;
   padding: 5px;
 }
@@ -218,7 +219,7 @@ h1.recipeTitle {
 .borderLeftRight {
   display: inline-block;
   position: relative;
-  color: #000 !important;
+  color: $black !important;
 }
 
 .borderLeftRight:hover,
@@ -271,8 +272,8 @@ h1.recipeTitle {
   background: $teal;
   position: relative;
   line-height: auto;
-  color: #fff;
-  border: 1px solid #000;
+  color: $white;
+  border: 1px solid $black;
   margin: 5px;
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -115,7 +115,7 @@ hr {
 }
 
 // Styling for active navigation link
-a.active {
+.navbar-nav .nav-link.active {
   font-weight: 900;
   color: $teal;
   //border-bottom: 1px solid $teal;

--- a/src/style.scss
+++ b/src/style.scss
@@ -152,18 +152,20 @@ hr {
 
 // Changing the border of any form fields
 .form-control {
-  border: 1px solid $black; // Style for "striped" tables
+  outline: 0 none;
+  border: 1px solid $black;
+
+  // Style for "striped" tables
   .table-striped tbody tr:nth-of-type(odd) {
     background-color: $lightest-blue;
   }
-  outline: 0 none;
-}
 
-// Changing the focused state of form fields
-.form-control:focus {
-  border: 3px solid $blue;
-  box-shadow: none;
-  outline: 0 none;
+  // Changing the focused state of form fields
+  &:focus {
+    border: 3px solid $blue;
+    box-shadow: none;
+    outline: 0 none;
+  }
 }
 
 // Changing the background for the text next to an input field

--- a/src/style.scss
+++ b/src/style.scss
@@ -110,8 +110,8 @@ hr {
 
 // Styling for active navigation link
 a.active {
-  font-weight: 900 !important;
-  color: $teal !important;
+  font-weight: 900;
+  color: $teal;
   //border-bottom: 1px solid $teal;
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -114,13 +114,6 @@ hr {
   }
 }
 
-// Styling for active navigation link
-.navbar-nav .nav-link.active {
-  font-weight: 900;
-  color: $teal;
-  //border-bottom: 1px solid $teal;
-}
-
 // Styling for nav "brand" (MixNJuice "logo")
 .navbar-brand {
   font-family: "Architects Daughter", cursive;
@@ -222,14 +215,14 @@ h1.recipeTitle {
 
 // Link animations in the header links
 // Credit to: https://emilkowalski.github.io/css-effects-snippets/
-.navbar-nav .nav-link.borderLeftRight {
+.navbar-nav .nav-link.borderLeftRight.active {
   display: inline-block;
   position: relative;
-  color: $black !important;
+  color: $black;
 
   &:hover,
   &:focus {
-    color: $teal !important;
+    color: $teal;
   }
 
   @media screen and (prefers-reduced-motion: reduce) {

--- a/src/style.scss
+++ b/src/style.scss
@@ -94,7 +94,7 @@ hr {
 }
 
 // Styling for dropdown links in the nav
-.navbar-nav .nav-link.dropdown-toggle {
+.navbar .navbar-nav .nav-link.dropdown-toggle {
   color: $black;
 
   &:hover,

--- a/src/style.scss
+++ b/src/style.scss
@@ -220,19 +220,49 @@ h1.recipeTitle {
 
 // Link animations in the header links
 // Credit to: https://emilkowalski.github.io/css-effects-snippets/
-.borderLeftRight {
+.navbar-nav .nav-link.borderLeftRight {
   display: inline-block;
   position: relative;
   color: $black !important;
-}
 
-.borderLeftRight:hover,
-.borderLeftRight:focus {
-  color: $teal !important;
-}
+  &:hover,
+  &:focus {
+    color: $teal !important;
+  }
 
-@media screen and (prefers-reduced-motion: reduce) {
-  .borderLeftRight::after {
+  @media screen and (prefers-reduced-motion: reduce) {
+    &::after {
+      content: "";
+      position: absolute;
+      width: 100%;
+      transform: scaleX(0);
+      height: 2px;
+      bottom: 0;
+      left: 0;
+      border-bottom: 1px solid $teal;
+      color: $teal;
+      transform-origin: bottom right;
+      transition: none;
+    }
+  }
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    &::after {
+      content: "";
+      position: absolute;
+      width: 100%;
+      transform: scaleX(0);
+      height: 2px;
+      bottom: 0;
+      left: 0;
+      border-bottom: 1px solid $teal;
+      color: $teal;
+      transform-origin: bottom right;
+      transition: none;
+    }
+  }
+
+  &::after {
     content: "";
     position: absolute;
     width: 100%;
@@ -243,28 +273,14 @@ h1.recipeTitle {
     border-bottom: 1px solid $teal;
     color: $teal;
     transform-origin: bottom right;
-    transition: none;
+    transition: transform 0.4s cubic-bezier(0.86, 0, 0.07, 1);
   }
-}
 
-.borderLeftRight::after {
-  content: "";
-  position: absolute;
-  width: 100%;
-  transform: scaleX(0);
-  height: 2px;
-  bottom: 0;
-  left: 0;
-  border-bottom: 1px solid $teal;
-  color: $teal;
-  transform-origin: bottom right;
-  transition: transform 0.4s cubic-bezier(0.86, 0, 0.07, 1);
-}
-
-.borderLeftRight:hover::after,
-.borderLeftRight:focus::after {
-  transform: scaleX(1);
-  transform-origin: bottom left;
+  &:hover::after,
+  &:focus::after {
+    transform: scaleX(1);
+    transform-origin: bottom left;
+  }
 }
 
 // Button animations
@@ -279,10 +295,36 @@ h1.recipeTitle {
   color: $white;
   border: 1px solid $black;
   margin: 5px;
-}
 
-@media screen and (prefers-reduced-motion: reduce) {
-  .btn::before {
+  @media screen and (prefers-reduced-motion: reduce) {
+    &::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+      height: 100%;
+      transform: translateX(-100%);
+      background: $blue;
+      transition: none;
+    }
+  }
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    &::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+      height: 100%;
+      transform: translateX(-100%);
+      background: $blue;
+      transition: none;
+    }
+  }
+
+  &::before {
     content: "";
     position: absolute;
     left: 0;
@@ -291,34 +333,22 @@ h1.recipeTitle {
     height: 100%;
     transform: translateX(-100%);
     background: $blue;
-    transition: none;
+    transition: transform 0.2s ease-in-out;
   }
-}
 
-.btn::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
-  transform: translateX(-100%);
-  background: $blue;
-  transition: transform 0.2s ease-in-out;
-}
+  &:hover,
+  &:focus {
+    border: 1px solid $teal;
+    background-color: $teal;
+  }
 
-.btn:hover,
-.btn:focus {
-  border: 1px solid $teal;
-  background-color: $teal;
-}
+  &:hover::before,
+  &:focus::before {
+    transform: translateX(0);
+  }
 
-.btn:hover::before,
-.btn:focus::before {
-  transform: translateX(0);
-}
-
-.btn span {
-  position: relative;
-  z-index: 1;
+  span {
+    position: relative;
+    z-index: 1;
+  }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -96,6 +96,11 @@ hr {
 // Styling for dropdown links in the nav
 .navbar-nav .nav-link.dropdown-toggle {
   color: $black;
+
+  &:hover,
+  &:focus {
+    color: $black;
+  }
 }
 
 // Styling for the dropdown menu

--- a/src/style.scss
+++ b/src/style.scss
@@ -5,7 +5,6 @@ $light-blue: #b1cefd;
 $blue: #77a6f7;
 $teal: #00887a;
 $lighter-red: #ffccbc;
-$white: #fff;
 
 // Changes the font site-wide
 * {

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css?family=Architects+Daughter|Quicksand&display=swap");
+
 $lightest-blue: #e7f0ff;
 $lighter-blue: #d3e3fc;
 $light-blue: #b1cefd;

--- a/src/style.scss
+++ b/src/style.scss
@@ -93,7 +93,7 @@ hr {
 }
 
 // Styling for dropdown links in the nav
-.dropdown-toggle {
+.navbar-nav .nav-link.dropdown-toggle {
   color: $black;
 }
 
@@ -101,6 +101,11 @@ hr {
 .dropdown-menu {
   text-align: center;
   background-color: $lightest-blue;
+
+  & .dropdown-item.active,
+  & .dropdown-item:active {
+    background-color: inherit;
+  }
 }
 
 // Styling for active navigation link
@@ -108,12 +113,6 @@ a.active {
   font-weight: 900 !important;
   color: $teal !important;
   //border-bottom: 1px solid $teal;
-}
-
-// Overriding Bootstrap background color for active dropdown items
-.dropdown-item.active,
-.dropdown-item:active {
-  background-color: inherit;
 }
 
 // Styling for nav "brand" (MixNJuice "logo")

--- a/src/style.scss
+++ b/src/style.scss
@@ -215,7 +215,7 @@ h1.recipeTitle {
 
 // Link animations in the header links
 // Credit to: https://emilkowalski.github.io/css-effects-snippets/
-.navbar-nav .nav-link.borderLeftRight.active {
+.navbar-nav .nav-link.borderLeftRight {
   display: inline-block;
   position: relative;
   color: $black;
@@ -275,6 +275,11 @@ h1.recipeTitle {
   &:focus::after {
     transform: scaleX(1);
     transform-origin: bottom left;
+  }
+
+  &.active {
+    font-weight: 900;
+    color: $teal;
   }
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -123,7 +123,6 @@ a.active {
 
 // Styling for checkboxes
 .form-check-input {
-  //-webkit-appearance: none;
   appearance: none;
   background-color: $white;
   border: 1px solid $black;


### PR DESCRIPTION
* `$white` is already declared in Bootstrap, removed it
* [Apply](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/sass-vars?expand=1#diff-4f4551829dd78334f41b7e816d80b553R97) two [changes](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/sass-vars?expand=1#diff-4f4551829dd78334f41b7e816d80b553R106) to increase specificity of the selectors so that `!important` can be removed
* [Removing](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/sass-vars?expand=1#diff-4f4551829dd78334f41b7e816d80b553R114) `!important` where it did not seem to be needed (tested in Chrome)
* [Switch](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/sass-vars?expand=1#diff-4f4551829dd78334f41b7e816d80b553R128) to using the color variables instead of `#000` and `#fff`
* Similarly use [the gray mixin](https://github.com/gusta-project/frontend/compare/master...ayan4m1:fix/sass-vars?expand=1#diff-4f4551829dd78334f41b7e816d80b553R143) to simplify our gray palette