### PR TITLE
Notify Mattermost via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
-version: 2
+version: 2.1
+
+orbs:
+  mattermost-notify: bulletlogic/mattermost-notify@0.0.1
+
 jobs:
   build:
     working_directory: ~/gusta-frontend
@@ -21,3 +25,33 @@ jobs:
       - run:
           name: test
           command: npm test
+  notify_success:
+    docker:
+      - image: byrnedo/alpine-curl:latest
+    steps:
+      - mattermost-notify/notify_on_success:
+          branches: '*'
+          reponame: 'gusta-project/website'
+          webhook: '$MATTERMOST_WEBHOOK_FRONTEND'
+  notify_failure:
+    docker:
+      - image: byrnedo/alpine-curl:latest
+    steps:
+      - mattermost-notify/notify_on_failure:
+          branches: '*'
+          reponame: 'gusta-project/website'
+          webhook: '$MATTERMOST_WEBHOOK_FRONTEND'
+
+workflows:
+  version: 2
+  main_workflow:
+    jobs:
+      - build
+      - notify_success:
+          context: webhooks
+          requires:
+            - build
+      - notify_failure:
+          context: webhooks
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  mattermost-notify: bulletlogic/mattermost-notify@dev:0.0.3
+  mattermost-notify: bulletlogic/mattermost-notify@0.0.2
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - mattermost-notify/notify_on_success:
           branches: '*'
-          reponame: 'gusta-project/website'
+          reponame: 'gusta-project/frontend'
           webhook: '$MATTERMOST_WEBHOOK_FRONTEND'
   notify_failure:
     docker:
@@ -39,7 +39,7 @@ jobs:
     steps:
       - mattermost-notify/notify_on_failure:
           branches: '*'
-          reponame: 'gusta-project/website'
+          reponame: 'gusta-project/frontend'
           webhook: '$MATTERMOST_WEBHOOK_FRONTEND'
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  mattermost-notify: bulletlogic/mattermost-notify@0.0.1
+  mattermost-notify: bulletlogic/mattermost-notify@dev:0.0.3
 
 jobs:
   build:


### PR DESCRIPTION
This PR modifies the CircleCI configuration to use a new orb that sends a webhook notification to our chat server on based on the success or failure of the unit tests.