### PR TITLE
Fix CircleCI failure due to missing context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,16 +30,12 @@ jobs:
       - image: byrnedo/alpine-curl:latest
     steps:
       - mattermost-notify/notify_on_success:
-          branches: '*'
-          reponame: 'gusta-project/frontend'
           webhook: '$MATTERMOST_WEBHOOK_FRONTEND'
   notify_failure:
     docker:
       - image: byrnedo/alpine-curl:latest
     steps:
       - mattermost-notify/notify_on_failure:
-          branches: '*'
-          reponame: 'gusta-project/frontend'
           webhook: '$MATTERMOST_WEBHOOK_FRONTEND'
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  mattermost-notify: bulletlogic/mattermost-notify@0.0.2
+  mattermost-notify: bulletlogic/mattermost-notify@0.0.4
 
 jobs:
   build:


### PR DESCRIPTION
If the security context is missing, the current CircleCI setup will fail because the curl command it uses fails when there is no URL provided. I have updated the upstream orb to exit with status 0 if there is no webhook URL.