### PR TITLE
Moving the button animation to its own class

### DIFF
--- a/src/components/Home/FeaturedMixer.js
+++ b/src/components/Home/FeaturedMixer.js
@@ -20,7 +20,7 @@ export class FeaturedMixer extends Component {
                   <Card.Text>
                     To figure out what could go here, but it&apos;s an idea.
                   </Card.Text>
-                  <Button variant="primary">
+                  <Button variant="primary" className="button-animation">
                     <span>Check out their recipes</span>
                   </Button>
                 </Col>

--- a/src/pages/Calculator.js
+++ b/src/pages/Calculator.js
@@ -292,12 +292,22 @@ export default class Calculator extends Component {
             Flavor Stash
             <span>&nbsp;&nbsp;&nbsp;</span>
             {this.state.ShowStash && (
-              <Button variant="info" size="sm" onClick={e => this.hideStash(e)}>
+              <Button
+                variant="info"
+                className="button-animation"
+                size="sm"
+                onClick={e => this.hideStash(e)}
+              >
                 <span>Hide</span>
               </Button>
             )}
             {!this.state.ShowStash && (
-              <Button variant="info" size="sm" onClick={e => this.showStash(e)}>
+              <Button
+                variant="info"
+                className="button-animation"
+                size="sm"
+                onClick={e => this.showStash(e)}
+              >
                 <span>Show</span>
               </Button>
             )}
@@ -337,12 +347,29 @@ export default class Calculator extends Component {
                               <td>{flavor.vendor.name}</td>
                               <td>{flavor.name}</td>
                               <td>
-                                <Button
-                                  onClick={this.addIngredient.bind(this, index)}
-                                  disabled={this.state.inuse[index]}
-                                >
-                                  <span>Add to Recipe</span>
-                                </Button>
+                                {this.state.inuse[index] && (
+                                  <Button
+                                    onClick={this.addIngredient.bind(
+                                      this,
+                                      index
+                                    )}
+                                    disabled={this.state.inuse[index]}
+                                  >
+                                    <span>Add to Recipe</span>
+                                  </Button>
+                                )}
+                                {!this.state.inuse[index] && (
+                                  <Button
+                                    className="button-animation"
+                                    onClick={this.addIngredient.bind(
+                                      this,
+                                      index
+                                    )}
+                                    disabled={this.state.inuse[index]}
+                                  >
+                                    <span>Add to Recipe</span>
+                                  </Button>
+                                )}
                               </td>
                             </tr>
                           );
@@ -385,6 +412,7 @@ export default class Calculator extends Component {
                         </td>
                         <td>
                           <Button
+                            className="button-animation"
                             onClick={this.removeIngredient.bind(this, index)}
                           >
                             <span>Remove</span>
@@ -442,7 +470,7 @@ export default class Calculator extends Component {
           </Form.Group>
           <Form.Row className="justify-content-center">
             <Form.Group as={Col} md="2">
-              <Button type="submit">
+              <Button className="button-animation" type="submit">
                 <span>Save</span>
               </Button>
               &nbsp;

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -81,8 +81,13 @@ export class Login extends Component {
                   </Form.Group>
                 )}
               </Field>
-              <Button variant="primary" type="submit" disabled={submitting}>
-                Login
+              <Button
+                className="button-animation"
+                variant="primary"
+                type="submit"
+                disabled={submitting}
+              >
+                <span>Login</span>
               </Button>
             </Form>
           )}

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -201,8 +201,13 @@ export class Register extends Component {
               </Form.Row>
               <Form.Row>
                 <Form.Group as={Col} md="2">
-                  <Button variant="primary" type="submit" disabled={submitting}>
-                    Register
+                  <Button
+                    className="button-animation"
+                    variant="primary"
+                    type="submit"
+                    disabled={submitting}
+                  >
+                    <span>Register</span>
                   </Button>
                 </Form.Group>
               </Form.Row>

--- a/src/pages/user/Profile.js
+++ b/src/pages/user/Profile.js
@@ -34,13 +34,13 @@ export default class Profile extends Component {
         <Row className="text-center">
           <Col>
             <ButtonGroup>
-              <Button variant="primary">
+              <Button className="button-animation" variant="primary">
                 <span>Message</span>
               </Button>
-              <Button variant="primary">
+              <Button className="button-animation" variant="primary">
                 <span>Follow</span>
               </Button>
-              <Button variant="primary">
+              <Button className="button-animation" variant="primary">
                 <span>Report</span>
               </Button>
             </ButtonGroup>

--- a/src/pages/user/Settings.js
+++ b/src/pages/user/Settings.js
@@ -98,7 +98,10 @@ export default class UserSettings extends Component {
                   </Form.Label>
                 </div>
                 <InputGroup.Prepend>
-                  <Button style={{ margin: '0px 10px' }}>
+                  <Button
+                    className="button-animation"
+                    style={{ margin: '0px 10px' }}
+                  >
                     <span>Upload</span>
                   </Button>
                 </InputGroup.Prepend>
@@ -111,7 +114,7 @@ export default class UserSettings extends Component {
           </Row>
           <Row className="text-center">
             <Col>
-              <Button>
+              <Button className="button-animation">
                 <span>Save</span>
               </Button>
             </Col>

--- a/src/style.scss
+++ b/src/style.scss
@@ -283,18 +283,22 @@ h1.recipeTitle {
   }
 }
 
-// Button animations
-// Credit to: https://emilkowalski.github.io/css-effects-snippets/
+// Universal button styling
 .btn {
   height: 40px;
   padding: 0 14px;
+  margin: 5px;
+  line-height: auto;
+}
+
+// Button animations
+// Credit to: https://emilkowalski.github.io/css-effects-snippets/
+.button-animation {
   overflow: hidden;
   background: $teal;
   position: relative;
-  line-height: auto;
   color: $white;
   border: 1px solid $black;
-  margin: 5px;
 
   @media screen and (prefers-reduced-motion: reduce) {
     &::before {


### PR DESCRIPTION
My first instinct when adding the button animation was that all buttons should have it. While building the recipe page, I've realized that some buttons, like the favorite button or the rating stars, should not have the animation. So I've moved the animation away from the universal `.btn` class to its own `.button-animation` class and updated all of the appropriate buttons to include this new class.