### PR TITLE
Navbar design changes

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -20,6 +20,7 @@ import Favorites from 'pages/user/Favorites';
 import FlavorStash from 'pages/user/FlavorStash';
 import UserSettings from 'pages/user/Settings';
 import ShoppingList from 'pages/user/ShoppingList';
+import Recipes from 'pages/Recipes';
 import Calculator from 'pages/Calculator';
 import Flavors from 'pages/Flavors';
 import Recipe from 'pages/Recipe';
@@ -47,6 +48,7 @@ export class App extends Component {
           <Route exact path="/" component={Home} />
           <Route exact path="/login" component={Login} />
           <Route exact path="/register" component={Register} />
+          <Route exact path="/recipes" component={Recipes} />
           <Route exact path="/calculator" component={Calculator} />
           <Route exact path="/flavors" component={Flavors} />
           <Route exact path="/recipe" component={Recipe} />

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -61,6 +61,7 @@ export default class Header extends Component {
                     )}
                     {this.renderNavDropdownItem('/user/settings', 'Settings')}
                   </NavDropdown>
+                  {this.renderNavItem('/flavors', 'Flavors')}
                   {this.renderNavItem('/login', 'Login')}
                   {this.renderNavItem('/register', 'Register')}
                 </Nav>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -40,7 +40,7 @@ export default class Header extends Component {
             <Navbar expand="lg">
               <Navbar.Brand>MixNJuice</Navbar.Brand>
               <Navbar.Toggle aria-controls="basic-navbar-nav" />
-              <Navbar.Collapse id="basic-navbar-nav">
+              <Navbar.Collapse>
                 <Nav>
                   {this.renderNavItem('/', 'Home')}
                   {this.renderNavItem('/calculator', 'Calculator')}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -34,17 +34,13 @@ export default class Header extends Component {
 
   render() {
     return (
-      <Container className="navigation-container" fluid>
-        <Row className="text-center">
+      <Container fluid>
+        <Row className="navigation-container">
           <Col>
-            <Navbar.Brand>MixNJuice</Navbar.Brand>
-          </Col>
-        </Row>
-        <Row>
-          <Col>
-            <Navbar expand="lg" className="justify-content-center">
+            <Navbar expand="lg">
+              <Navbar.Brand>MixNJuice</Navbar.Brand>
               <Navbar.Toggle aria-controls="basic-navbar-nav" />
-              <Navbar.Collapse className="justify-content-center">
+              <Navbar.Collapse id="basic-navbar-nav">
                 <Nav>
                   {this.renderNavItem('/', 'Home')}
                   {this.renderNavItem('/calculator', 'Calculator')}
@@ -69,7 +65,6 @@ export default class Header extends Component {
                 </Nav>
               </Navbar.Collapse>
             </Navbar>
-            <hr />
           </Col>
         </Row>
       </Container>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -9,7 +9,7 @@ export default class Header extends Component {
         as={NavLink}
         exact
         to={to}
-        className="borderLeftRight px-3"
+        className="nav--link-custom px-3"
         activeClassName="active"
       >
         {text}
@@ -23,7 +23,7 @@ export default class Header extends Component {
         as={NavLink}
         exact
         to={to}
-        className="borderLeftRight"
+        className="nav--link-custom"
         activeClassName="active"
       >
         {text}
@@ -46,6 +46,7 @@ export default class Header extends Component {
                   {this.renderNavItem('/calculator', 'Calculator')}
                   {this.renderNavItem('/recipe', 'Recipes')}
                   {this.renderNavItem('/flavors', 'Flavors')}
+                  {this.renderNavItem('/recipes', 'Recipes')}
                   <NavDropdown title="User">
                     {this.renderNavDropdownItem('/user/profile', 'Profile')}
                     {this.renderNavDropdownItem('/user/recipes', 'Recipes')}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -43,10 +43,10 @@ export default class Header extends Component {
               <Navbar.Collapse>
                 <Nav>
                   {this.renderNavItem('/', 'Home')}
+                  {this.renderNavItem('/recipes', 'Recipes')}
                   {this.renderNavItem('/calculator', 'Calculator')}
                   {this.renderNavItem('/recipe', 'Recipes')}
                   {this.renderNavItem('/flavors', 'Flavors')}
-                  {this.renderNavItem('/recipes', 'Recipes')}
                   <NavDropdown title="User">
                     {this.renderNavDropdownItem('/user/profile', 'Profile')}
                     {this.renderNavDropdownItem('/user/recipes', 'Recipes')}

--- a/src/components/Header/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__snapshots__/Header.test.js.snap
@@ -2,30 +2,22 @@
 
 exports[`<Header /> renders correctly 1`] = `
 <div
-  className="navigation-container container-fluid"
+  className="container-fluid"
 >
   <div
-    className="text-center row"
-  >
-    <div
-      className="col"
-    >
-      <span
-        className="navbar-brand"
-      >
-        MixNJuice
-      </span>
-    </div>
-  </div>
-  <div
-    className="row"
+    className="navigation-container row"
   >
     <div
       className="col"
     >
       <nav
-        className="justify-content-center navbar navbar-expand-lg navbar-light"
+        className="navbar navbar-expand-lg navbar-light"
       >
+        <span
+          className="navbar-brand"
+        >
+          MixNJuice
+        </span>
         <button
           aria-controls="basic-navbar-nav"
           aria-label="Toggle navigation"
@@ -39,7 +31,7 @@ exports[`<Header /> renders correctly 1`] = `
         </button>
         <div
           aria-expanded={null}
-          className="justify-content-center navbar-collapse collapse"
+          className="navbar-collapse collapse"
         >
           <div
             className="navbar-nav"
@@ -47,7 +39,7 @@ exports[`<Header /> renders correctly 1`] = `
           >
             <a
               aria-current="page"
-              className="borderLeftRight px-3 nav-link active"
+              className="nav--link-custom px-3 nav-link active"
               data-rb-event-key={null}
               disabled={false}
               href="/"
@@ -58,7 +50,17 @@ exports[`<Header /> renders correctly 1`] = `
             </a>
             <a
               aria-current={null}
-              className="borderLeftRight px-3 nav-link"
+              className="nav--link-custom px-3 nav-link"
+              data-rb-event-key={null}
+              disabled={false}
+              href="/recipes"
+              onClick={[Function]}
+            >
+              Recipes
+            </a>
+            <a
+              aria-current={null}
+              className="nav--link-custom px-3 nav-link"
               data-rb-event-key={null}
               disabled={false}
               href="/calculator"
@@ -107,7 +109,7 @@ exports[`<Header /> renders correctly 1`] = `
               >
                 <a
                   aria-current={null}
-                  className="borderLeftRight dropdown-item"
+                  className="nav--link-custom dropdown-item"
                   disabled={false}
                   href="/user/profile"
                   onClick={[Function]}
@@ -117,7 +119,7 @@ exports[`<Header /> renders correctly 1`] = `
                 </a>
                 <a
                   aria-current={null}
-                  className="borderLeftRight dropdown-item"
+                  className="nav--link-custom dropdown-item"
                   disabled={false}
                   href="/user/recipes"
                   onClick={[Function]}
@@ -127,7 +129,7 @@ exports[`<Header /> renders correctly 1`] = `
                 </a>
                 <a
                   aria-current={null}
-                  className="borderLeftRight dropdown-item"
+                  className="nav--link-custom dropdown-item"
                   disabled={false}
                   href="/user/favorites"
                   onClick={[Function]}
@@ -137,7 +139,7 @@ exports[`<Header /> renders correctly 1`] = `
                 </a>
                 <a
                   aria-current={null}
-                  className="borderLeftRight dropdown-item"
+                  className="nav--link-custom dropdown-item"
                   disabled={false}
                   href="/user/flavor-stash"
                   onClick={[Function]}
@@ -147,7 +149,7 @@ exports[`<Header /> renders correctly 1`] = `
                 </a>
                 <a
                   aria-current={null}
-                  className="borderLeftRight dropdown-item"
+                  className="nav--link-custom dropdown-item"
                   disabled={false}
                   href="/user/shopping-list"
                   onClick={[Function]}
@@ -157,7 +159,7 @@ exports[`<Header /> renders correctly 1`] = `
                 </a>
                 <a
                   aria-current={null}
-                  className="borderLeftRight dropdown-item"
+                  className="nav--link-custom dropdown-item"
                   disabled={false}
                   href="/user/settings"
                   onClick={[Function]}
@@ -169,7 +171,17 @@ exports[`<Header /> renders correctly 1`] = `
             </div>
             <a
               aria-current={null}
-              className="borderLeftRight px-3 nav-link"
+              className="nav--link-custom px-3 nav-link"
+              data-rb-event-key={null}
+              disabled={false}
+              href="/flavors"
+              onClick={[Function]}
+            >
+              Flavors
+            </a>
+            <a
+              aria-current={null}
+              className="nav--link-custom px-3 nav-link"
               data-rb-event-key={null}
               disabled={false}
               href="/login"
@@ -179,7 +191,7 @@ exports[`<Header /> renders correctly 1`] = `
             </a>
             <a
               aria-current={null}
-              className="borderLeftRight px-3 nav-link"
+              className="nav--link-custom px-3 nav-link"
               data-rb-event-key={null}
               disabled={false}
               href="/register"
@@ -190,7 +202,6 @@ exports[`<Header /> renders correctly 1`] = `
           </div>
         </div>
       </nav>
-      <hr />
     </div>
   </div>
 </div>

--- a/src/components/Header/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__snapshots__/Header.test.js.snap
@@ -70,7 +70,7 @@ exports[`<Header /> renders correctly 1`] = `
             </a>
             <a
               aria-current={null}
-              className="borderLeftRight px-3 nav-link"
+              className="nav--link-custom px-3 nav-link"
               data-rb-event-key={null}
               disabled={false}
               href="/recipe"
@@ -80,7 +80,7 @@ exports[`<Header /> renders correctly 1`] = `
             </a>
             <a
               aria-current={null}
-              className="borderLeftRight px-3 nav-link"
+              className="nav--link-custom px-3 nav-link"
               data-rb-event-key={null}
               disabled={false}
               href="/flavors"

--- a/src/pages/Recipe.js
+++ b/src/pages/Recipe.js
@@ -7,6 +7,10 @@ import { Container, Row, Col, Table } from 'react-bootstrap';
 import recipes from '../data/recipes.json';
 
 export default class Recipe extends Component {
+  static propTypes = {
+    location: PropTypes.object
+  };
+
   constructor(...args) {
     super(...args);
 
@@ -106,7 +110,3 @@ export default class Recipe extends Component {
     );
   }
 }
-
-Recipe.propTypes = {
-  location: PropTypes.object
-};

--- a/src/pages/Recipe.test.js
+++ b/src/pages/Recipe.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Recipe from './Recipe';
+import recipes from '../data/recipes.json';
+
+describe('<Recipe />', () => {
+  const actions = {
+    registerUser: jest.fn()
+  };
+  const props = search => ({
+    location: {
+      search
+    }
+  });
+
+  it('renders correctly', () => {
+    const component = renderer.create(<Recipe {...props('?id=1')} />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('can findRecipe', () => {
+    const component = renderer.create(
+      <Recipe actions={actions} {...props('?id=1')} />
+    );
+    const { instance } = component.root.findByType(Recipe);
+
+    expect(instance).toBeDefined();
+    instance.findRecipe();
+    expect(instance.state).toEqual({ ...recipes[0], flavorTotal: 9 });
+  });
+});

--- a/src/pages/Recipes.js
+++ b/src/pages/Recipes.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import { Container, Row, Col } from 'react-bootstrap';
+
+export default class Recipes extends Component {
+  render() {
+    return (
+      <Container>
+        <Row className="text-center">
+          <Col>
+            <h1>Recipes search page</h1>
+          </Col>
+        </Row>
+      </Container>
+    );
+  }
+}

--- a/src/pages/Recipes.test.js
+++ b/src/pages/Recipes.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Recipes from './Recipes';
+
+describe('<Recipes />', () => {
+  it('renders correctly', () => {
+    const component = renderer.create(<Recipes />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/pages/__snapshots__/Recipe.test.js.snap
+++ b/src/pages/__snapshots__/Recipe.test.js.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Recipe /> renders correctly 1`] = `
+<div
+  className="text-center container"
+>
+  <div
+    className="row"
+  >
+    <div
+      className="col-md-2 offset-md-3"
+    >
+      <img
+        alt="card test"
+        className="w-100 img-thumbnail"
+        src="/media/card-test-1.jpg"
+      />
+    </div>
+    <div
+      className="col-md-4"
+    >
+      <h1
+        className="recipeTitle"
+      >
+        Thanks, Obama
+      </h1>
+      <h2>
+        Created by
+         
+        <a
+          href="/user?id=5420"
+        >
+          JosefBud
+        </a>
+      </h2>
+      <p>
+        on 
+        March 20 2019, 16:39:00
+      </p>
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <div
+      className="col-md-6 offset-md-3"
+    >
+      <table
+        className="table table-striped table-bordered table-hover"
+      >
+        <thead>
+          <tr>
+            <th>
+              Flavor
+            </th>
+            <th>
+              Percent
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a
+                href="/flavor?id=1"
+              >
+                FW
+                 
+                Blue Raspberry
+              </a>
+            </td>
+            <td>
+              3.0
+              %
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="/flavor?id=2"
+              >
+                TFA
+                 
+                Cherry Extract
+              </a>
+            </td>
+            <td>
+              1.5
+              %
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="/flavor?id=3"
+              >
+                CAP
+                 
+                Lemon Lime
+              </a>
+            </td>
+            <td>
+              4.0
+              %
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="/flavor?id=4"
+              >
+                CAP
+                 
+                Super Sweet
+              </a>
+            </td>
+            <td>
+              0.5
+              %
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <div
+      className="col"
+    >
+      <h3>
+        30
+        % PG / 
+        70
+        % VG
+      </h3>
+      <h3>
+        Shake & Vape
+      </h3>
+      <h3>
+        Flavor total: 
+        9
+        %
+      </h3>
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <div
+      className="col"
+    >
+      <h2>
+        Notes
+      </h2>
+      <p>
+        IMPORTANT: CAP Lemon Lime's gravity (g per ml) by default is way above what it should be. If you mix by weight, mix CAP Lemon Lime as 1g = 1ml.
+ 
+ CAP Super Sweet is optional. 
+ 
+ VapeWild doesn't add cooling, but 2 drops per 30ml of WS-23 works well if you're into that.
+ 
+ No steep required, shake and vape!
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/src/pages/__snapshots__/Recipes.test.js.snap
+++ b/src/pages/__snapshots__/Recipes.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Recipes /> renders correctly 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="text-center row"
+  >
+    <div
+      className="col"
+    >
+      <h1>
+        Recipes search page
+      </h1>
+    </div>
+  </div>
+</div>
+`;

--- a/src/style.scss
+++ b/src/style.scss
@@ -250,22 +250,6 @@ h1.recipeTitle {
     }
   }
 
-  @media screen and (prefers-reduced-motion: reduce) {
-    &::after {
-      content: "";
-      position: absolute;
-      width: 100%;
-      transform: scaleX(0);
-      height: 2px;
-      bottom: 0;
-      left: 0;
-      border-bottom: 1px solid $teal;
-      color: $teal;
-      transform-origin: bottom right;
-      transition: none;
-    }
-  }
-
   &::after {
     content: "";
     position: absolute;

--- a/src/style.scss
+++ b/src/style.scss
@@ -5,6 +5,7 @@ $lighter-blue: #d3e3fc;
 $light-blue: #b1cefd;
 $blue: #77a6f7;
 $teal: #00887a;
+$baby-blue: #00bad3;
 $lighter-red: #ffccbc;
 $shadow-grey: #777;
 
@@ -311,7 +312,7 @@ input {
       width: 100%;
       height: 100%;
       transform: translateX(-100%);
-      background: $blue;
+      background: $baby-blue;
       transition: none;
     }
   }
@@ -325,7 +326,7 @@ input {
       width: 100%;
       height: 100%;
       transform: translateX(-100%);
-      background: $blue;
+      background: $baby-blue;
       transition: none;
     }
   }
@@ -338,13 +339,13 @@ input {
     width: 100%;
     height: 100%;
     transform: translateX(-100%);
-    background: $blue;
+    background: $baby-blue;
     transition: transform 0.2s ease-in-out;
   }
 
   &:hover,
   &:focus {
-    border: 1px solid $teal;
+    border: 1px solid $black;
     background-color: $teal;
   }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -225,6 +225,7 @@ h1.recipeTitle {
   display: inline-block;
   position: relative;
   color: $black;
+  transition: 0.5s;
 
   &:hover,
   &:focus {
@@ -232,6 +233,8 @@ h1.recipeTitle {
   }
 
   @media screen and (prefers-reduced-motion: reduce) {
+    transition: none;
+
     &::after {
       content: "";
       position: absolute;

--- a/src/style.scss
+++ b/src/style.scss
@@ -6,6 +6,7 @@ $light-blue: #b1cefd;
 $blue: #77a6f7;
 $teal: #00887a;
 $lighter-red: #ffccbc;
+$shadow-grey: #777;
 
 // Changes the font site-wide
 * {
@@ -81,7 +82,12 @@ hr {
 
 // Gradient background for the navigation container
 .navigation-container {
-  background: linear-gradient(180deg, $light-blue 0%, $white 100%);
+  background: $lighter-blue;
+  height: 10%;
+  margin: 1em;
+  border: 2px solid $teal;
+  border-radius: 20px;
+  box-shadow: 8px 8px 20px $shadow-grey;
 }
 
 // On screen sizes below ~1200px width, the nav links look a little weird by
@@ -117,7 +123,7 @@ hr {
 // Styling for nav "brand" (MixNJuice "logo")
 .navbar-brand {
   font-family: "Architects Daughter", cursive;
-  font-size: 4em;
+  font-size: 3em;
 }
 
 // Styling for checkboxes

--- a/src/style.scss
+++ b/src/style.scss
@@ -128,6 +128,13 @@ hr {
   font-size: 3em;
 }
 
+// Centering nav contents for phone screens
+@media (max-width: 700px) {
+  .navbar {
+    justify-content: center;
+  }
+}
+
 // Styling for checkboxes
 .form-check-input {
   appearance: none;

--- a/src/style.scss
+++ b/src/style.scss
@@ -180,18 +180,18 @@ hr {
 }
 
 // Card titles
-div.h5 {
+.h5 {
   font-size: 1.1em;
   font-weight: 900;
 }
 
 // Card bodies
-p.card-text {
+.card-text {
   font-size: 0.9em;
 }
 
 // Card headers
-div.card-header {
+.card-header {
   font-size: 1.4em;
   font-weight: 900;
 }
@@ -202,13 +202,13 @@ input {
 }
 
 // Style for file inputs
-input[type="file"] {
+.custom-file-input[type="file"] {
   border: 1px solid $black;
   border-radius: 0.25rem;
   padding: 5px;
 }
 
-h1.recipeTitle {
+.recipeTitle {
   font-size: 3em;
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -230,7 +230,7 @@ input {
 
 // Link animations in the header links
 // Credit to: https://emilkowalski.github.io/css-effects-snippets/
-.navbar-nav .nav-link.borderLeftRight {
+.navbar-nav .nav-link.nav--link-custom {
   display: inline-block;
   text-align: center;
   position: relative;

--- a/src/style.scss
+++ b/src/style.scss
@@ -117,6 +117,8 @@ hr {
   & .dropdown-item.active,
   & .dropdown-item:active {
     background-color: inherit;
+    font-weight: 900;
+    color: $teal;
   }
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -232,6 +232,7 @@ input {
 // Credit to: https://emilkowalski.github.io/css-effects-snippets/
 .navbar-nav .nav-link.borderLeftRight {
   display: inline-block;
+  text-align: center;
   position: relative;
   color: $black;
   transition: 0.5s;


### PR DESCRIPTION
https://github.com/gusta-project/frontend/commit/d054ade1be5fa031147cb9a7c294079c07cc91d4 Moved the MixNJuice "brand logo" from above & center to inline & left. Changed the overall nav to no longer be centered, defaulting to align left. Removed the separator line between the nav and the page, since it wasn't really necessary with the new navbar style.

https://github.com/gusta-project/frontend/commit/579e3e31f72e916334f28285f75ccf4fdbe72193 Added a "shadow grey" color variable. Added various styling to give the navbar a floating look with a border, rounded corners, drop shadow, and more. Changed the background from a gradient to a solid light blue. With the "brand logo" being moved back inside the navbar, I also reduced the font size of that.

https://github.com/gusta-project/frontend/commit/b6c34fb7708bfec8eb6dba173d7b8cc613189ff8 Added a transition duration for the nav links, which really just makes the color change on hover a little smoother.

https://github.com/gusta-project/frontend/commit/7703c22726a8a8abce289583f3053b589f0280df Removed a superfluous `prefers-reduced-motion` nest

https://github.com/gusta-project/frontend/commit/813705cf941ade575e56b36678bb4a8d0b975a8e Dropdown item styles became slightly broken after the SCSS changes in https://github.com/gusta-project/frontend/pull/16 removed the `a.active` styling. This is just putting that styling back in the `.dropdown-item` nest.

https://github.com/gusta-project/frontend/commit/cc5e2169d543de3bb31f007e4d9dbdd7f07f5f4e **Unrelated to the navbar**, but I fixed most of the stylelint warnings regarding how selectors were being used.

https://github.com/gusta-project/frontend/commit/423c014415a15a0bbce109ad16b082df38cf0add At 700px screen width, the hamburger icon was aligning to the left side of the navbar, so I centered the navbar contents for screens up to 700px wide.

https://github.com/gusta-project/frontend/commit/a957a34a3fa57d0e9b563d33b370e9c41a66b2e1 Centered the text for nav links, mainly due to "Create Recipe" having a line break at & below 1134px screen width. With this line break, it was aligning to the left, and therefore the space between it and its neighboring nav links looked drastically different. Tablet users and grandparents with outdated monitors, rejoice.

https://github.com/gusta-project/frontend/commit/0e22e7ee950ea11183df77e8153cfde45040ceca Simply renaming `borderLeftRight` class to `nav--link-custom` since it's no longer just the "bottom border left to right" animation and has become the overall custom styling for nav links. I also added the "Recipes" link to the navbar. _(Forgot to add that to the commit message - my bad!)_

https://github.com/gusta-project/frontend/commit/7ed3bf3d98b16b79f74c61c6e8444e2877c02585 Added Recipes page to the `App.js` router with a placeholder `Recipes.js` page.

https://github.com/gusta-project/frontend/commit/46bf2862ac2d867d5c751bd1df4e1447bc59d28f Added the Flavors page link back to the navbar.

https://github.com/gusta-project/frontend/commit/824673d6d41085a5a1df005e9837386b7b487e33 **Unrelated to the navbar**, but I changed the background color of the button hover effect since the previous `$blue` color seemed a tad too light for the white text. Added a `$baby-blue` color variable and used that. Also changed the button border to stay black on hover rather than change colors.

https://github.com/gusta-project/frontend/commit/7c7e596650a3862980e80e3e78bd65727166e7fd And just as all branches end: updated snapshot tests.