### PR TITLE
Fetch current user after auth

### DIFF
--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -59,10 +59,9 @@ const requestToken = (emailAddress, password) => ({
   password
 });
 
-const requestTokenSuccess = ({ token, expiration, userId }) => ({
+const requestTokenSuccess = ({ token, expiration }) => ({
   type: types.REQUEST_TOKEN_SUCCESS,
   expiration,
-  userId,
   token
 });
 
@@ -221,9 +220,6 @@ export const reducer = (state = initialState, action = {}) => {
           ...state.authorization,
           accessToken: action.token,
           expiration: action.expiration
-        },
-        user: {
-          id: action.userId
         }
       };
     case types.REQUEST_TOKEN_FAILURE:

--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -59,9 +59,10 @@ const requestToken = (emailAddress, password) => ({
   password
 });
 
-const requestTokenSuccess = (token, expiration) => ({
+const requestTokenSuccess = ({ token, expiration, userId }) => ({
   type: types.REQUEST_TOKEN_SUCCESS,
   expiration,
+  userId,
   token
 });
 
@@ -220,6 +221,9 @@ export const reducer = (state = initialState, action = {}) => {
           ...state.authorization,
           accessToken: action.token,
           expiration: action.expiration
+        },
+        user: {
+          id: action.userId
         }
       };
     case types.REQUEST_TOKEN_FAILURE:

--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -84,9 +84,8 @@ const requestCurrentUserFailure = error => ({
   error
 });
 
-const loginUserSuccess = user => ({
-  type: types.LOGIN_USER_SUCCESS,
-  user
+const loginUserSuccess = () => ({
+  type: types.LOGIN_USER_SUCCESS
 });
 
 const loginUserFailure = error => ({

--- a/src/reducers/application.test.js
+++ b/src/reducers/application.test.js
@@ -124,14 +124,13 @@ describe('application reducer', () => {
   });
 
   it('has LOGIN_USER_SUCCESS action', () => {
-    expect(actions.loginUserSuccess(user)).toEqual({
-      type: types.LOGIN_USER_SUCCESS,
-      user
+    expect(actions.loginUserSuccess()).toEqual({
+      type: types.LOGIN_USER_SUCCESS
     });
   });
 
   it('reduces LOGIN_USER_SUCCESS action', () => {
-    const action = actions.loginUserSuccess({ id: 123, name: 'Dave' });
+    const action = actions.loginUserSuccess();
 
     expect(reducer({}, action)).toEqual({
       loggingIn: false

--- a/src/reducers/application.test.js
+++ b/src/reducers/application.test.js
@@ -56,27 +56,20 @@ describe('application reducer', () => {
   });
 
   it('has REQUEST_TOKEN_SUCCESS action', () => {
-    const userId = user.id;
-
-    expect(actions.requestTokenSuccess({ token, expiration, userId })).toEqual({
+    expect(actions.requestTokenSuccess({ token, expiration })).toEqual({
       type: types.REQUEST_TOKEN_SUCCESS,
       expiration,
-      userId,
       token
     });
   });
 
   it('reduces REQUEST_TOKEN_SUCCESS action', () => {
-    const userId = user.id;
-    const action = actions.requestTokenSuccess({ token, expiration, userId });
+    const action = actions.requestTokenSuccess({ token, expiration });
 
     expect(reducer({}, action)).toEqual({
       authorization: {
         accessToken: token,
         expiration
-      },
-      user: {
-        id: userId
       }
     });
   });

--- a/src/reducers/application.test.js
+++ b/src/reducers/application.test.js
@@ -56,20 +56,27 @@ describe('application reducer', () => {
   });
 
   it('has REQUEST_TOKEN_SUCCESS action', () => {
-    expect(actions.requestTokenSuccess(token, expiration)).toEqual({
+    const userId = user.id;
+
+    expect(actions.requestTokenSuccess({ token, expiration, userId })).toEqual({
       type: types.REQUEST_TOKEN_SUCCESS,
       expiration,
+      userId,
       token
     });
   });
 
   it('reduces REQUEST_TOKEN_SUCCESS action', () => {
-    const action = actions.requestTokenSuccess(token, expiration);
+    const userId = user.id;
+    const action = actions.requestTokenSuccess({ token, expiration, userId });
 
     expect(reducer({}, action)).toEqual({
       authorization: {
         accessToken: token,
         expiration
+      },
+      user: {
+        id: userId
       }
     });
   });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,13 @@
 import { combineReducers } from 'redux';
 
-import { reducer as application } from './application';
+import {
+  reducer as application,
+  initialState as applicationState
+} from './application';
+
+export const initialState = {
+  application: applicationState
+};
 
 export default combineReducers({
   application

--- a/src/sagas/application.js
+++ b/src/sagas/application.js
@@ -34,9 +34,10 @@ function* requestTokenWorker({ emailAddress, password }) {
     if (result.success) {
       const {
         data: {
-          access_token: accessToken,
+          access_token: token,
           token_type: tokenType,
-          expires_in: expiresIn
+          expires_in: expiresIn,
+          userId
         }
       } = result.response;
 
@@ -46,7 +47,7 @@ function* requestTokenWorker({ emailAddress, password }) {
 
       const expiration = dayjs().add(expiresIn, 'seconds');
 
-      yield put(actions.requestTokenSuccess(accessToken, expiration));
+      yield put(actions.requestTokenSuccess({ token, expiration, userId }));
       yield put(
         actions.popToast({
           title: 'Logged in',

--- a/src/sagas/application.js
+++ b/src/sagas/application.js
@@ -36,8 +36,7 @@ function* requestTokenWorker({ emailAddress, password }) {
         data: {
           access_token: token,
           token_type: tokenType,
-          expires_in: expiresIn,
-          userId
+          expires_in: expiresIn
         }
       } = result.response;
 
@@ -47,7 +46,7 @@ function* requestTokenWorker({ emailAddress, password }) {
 
       const expiration = dayjs().add(expiresIn, 'seconds');
 
-      yield put(actions.requestTokenSuccess({ token, expiration, userId }));
+      yield put(actions.requestTokenSuccess({ token, expiration }));
       yield put(
         actions.popToast({
           title: 'Logged in',
@@ -78,18 +77,22 @@ function* requestTokenWorker({ emailAddress, password }) {
 function* requestCurrentUserWorker() {
   try {
     const endpoint = {
-      url: '/api/user/current',
+      url: '/user/current',
       method: 'GET'
     };
     const result = yield call(request.execute, { endpoint });
 
     // update user in state or throw an error
     if (result.success) {
-      yield put(actions.requestCurrentUserSuccess(result.data));
+      const {
+        response: { data }
+      } = result;
+
+      yield put(actions.requestCurrentUserSuccess(data));
     } else if (result.error) {
       throw result.error;
     } else {
-      throw new Error('Request failed for an unspecified reason!');
+      throw new Error('Failed to get current user!');
     }
   } catch (error) {
     const { message } = error;

--- a/src/sagas/application.test.js
+++ b/src/sagas/application.test.js
@@ -54,10 +54,10 @@ describe('application sagas', () => {
 
     expect(result.value).toEqual(
       put(
-        actions.requestTokenSuccess(
-          accessToken,
-          dayjs().add(expiresIn, 'second')
-        )
+        actions.requestTokenSuccess({
+          token: accessToken,
+          expiration: dayjs().add(expiresIn, 'second')
+        })
       )
     );
 
@@ -241,7 +241,9 @@ describe('application sagas', () => {
 
     const expiration = dayjs().add(expiresIn, 'seconds');
 
-    result = gen.next(actions.requestTokenSuccess(accessToken, expiration));
+    result = gen.next(
+      actions.requestTokenSuccess({ token: accessToken, expiration })
+    );
 
     expect(window.localStorage.setItem).toHaveBeenCalledTimes(2);
 
@@ -307,10 +309,10 @@ describe('application sagas', () => {
     );
 
     result = gen.next(
-      actions.requestTokenSuccess(
-        accessToken,
-        dayjs().add(expiresIn, 'seconds')
-      )
+      actions.requestTokenSuccess({
+        token: accessToken,
+        expiration: dayjs().add(expiresIn, 'seconds')
+      })
     );
 
     expect(result.value).toEqual(put(actions.requestCurrentUser()));

--- a/src/sagas/application.test.js
+++ b/src/sagas/application.test.js
@@ -17,7 +17,7 @@ describe('application sagas', () => {
   const emailAddress = 'testing@example.org';
   const password = 'test';
   const currentUserEndpoint = {
-    url: '/api/user/current',
+    url: '/user/current',
     method: 'GET'
   };
   const tokenEndpoint = {
@@ -112,7 +112,7 @@ describe('application sagas', () => {
     );
   });
 
-  it('handles expected error in requestTokenWorker', () => {
+  it('handles request failure in requestTokenWorker', () => {
     const error = new Error('Something went wrong.');
     const gen = workers.requestTokenWorker({ emailAddress, password });
 
@@ -163,13 +163,15 @@ describe('application sagas', () => {
 
     result = gen.next({
       success: true,
-      data: user
+      response: {
+        data: user
+      }
     });
 
     expect(result.value).toEqual(put(actions.requestCurrentUserSuccess(user)));
   });
 
-  it('handles expected error in requestCurrentUserWorker', () => {
+  it('handles request failure in requestCurrentUserWorker', () => {
     const error = new Error('An error occurred.');
     const gen = workers.requestCurrentUserWorker();
 

--- a/src/sagas/application.test.js
+++ b/src/sagas/application.test.js
@@ -3,7 +3,7 @@ import MockDate from 'mockdate';
 import { all, put, call, take, select, delay } from 'redux-saga/effects';
 
 import request from 'utils/request';
-import { isLoggedIn } from 'selectors/application';
+import { isLoggedIn, getUser } from 'selectors/application';
 import { actions, types } from 'reducers/application';
 import appSaga, { watchers, workers } from './application';
 
@@ -61,17 +61,6 @@ describe('application sagas', () => {
       )
     );
 
-    result = gen.next();
-
-    expect(result.value).toEqual(
-      put(
-        actions.popToast({
-          title: 'Logged in',
-          icon: 'check',
-          message: 'You have been authenticated.'
-        })
-      )
-    );
     MockDate.reset();
   });
 
@@ -257,6 +246,22 @@ describe('application sagas', () => {
       JSON.stringify(expiration.toISOString())
     ]);
 
+    expect(result.value).toEqual(
+      put(
+        actions.popToast({
+          title: 'Logged in',
+          icon: 'check',
+          message: 'You have been authenticated.'
+        })
+      )
+    );
+
+    result = gen.next();
+
+    expect(result.value).toEqual(select(getUser));
+
+    result = gen.next(null);
+
     expect(result.value).toEqual(put(actions.requestCurrentUser()));
 
     result = gen.next();
@@ -270,8 +275,10 @@ describe('application sagas', () => {
 
     result = gen.next(actions.requestCurrentUserSuccess(user));
 
-    expect(result.value).toEqual(put(actions.loginUserSuccess(user)));
+    expect(result.value).toEqual(put(actions.loginUserSuccess()));
   });
+
+  it('exits loginUserWorker early if current user in store', () => {});
 
   it('exits loginUserWorker early if logged in', () => {
     const gen = workers.loginUserWorker({ emailAddress, password });
@@ -281,6 +288,22 @@ describe('application sagas', () => {
     expect(result.value).toEqual(select(isLoggedIn));
 
     result = gen.next(true);
+
+    expect(result.value).toEqual(
+      put(
+        actions.popToast({
+          title: 'Logged in',
+          icon: 'check',
+          message: 'You have been authenticated.'
+        })
+      )
+    );
+
+    result = gen.next();
+
+    expect(result.value).toEqual(select(getUser));
+
+    result = gen.next(user);
 
     expect(result.value).toEqual(put(actions.loginUserSuccess()));
 
@@ -316,6 +339,22 @@ describe('application sagas', () => {
         expiration: dayjs().add(expiresIn, 'seconds')
       })
     );
+
+    expect(result.value).toEqual(
+      put(
+        actions.popToast({
+          title: 'Logged in',
+          icon: 'check',
+          message: 'You have been authenticated.'
+        })
+      )
+    );
+
+    result = gen.next();
+
+    expect(result.value).toEqual(select(getUser));
+
+    result = gen.next(null);
 
     expect(result.value).toEqual(put(actions.requestCurrentUser()));
 

--- a/src/selectors/application.js
+++ b/src/selectors/application.js
@@ -5,12 +5,12 @@ export const getApplication = state => state.application;
 
 export const isLoggingIn = createSelector(
   getApplication,
-  application => application.loggingIn
+  application => Boolean(application.loggingIn)
 );
 
 export const isLoggingOut = createSelector(
   getApplication,
-  application => application.loggingOut
+  application => Boolean(application.loggingOut)
 );
 
 export const getUser = createSelector(

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,8 @@ import dayjs from 'dayjs';
 import React, { createElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
+import { getApplication, getAuthorization } from 'selectors/application';
+
 /* eslint-disable react/display-name, react/prop-types */
 
 /**
@@ -67,6 +69,10 @@ export const buildUrl = endpoint => {
 };
 
 export const getInitialState = () => {
+  // this needs to be require()d because an import results in a
+  // circular dependency
+  const { initialState } = require('reducers');
+
   try {
     const [accessToken, expiration] = [
       localStorage.getItem('accessToken'),
@@ -74,7 +80,7 @@ export const getInitialState = () => {
     ];
 
     if (!accessToken) {
-      return {};
+      return initialState;
     }
 
     const expirationDate = dayjs(JSON.parse(expiration));
@@ -82,18 +88,21 @@ export const getInitialState = () => {
     if (!expirationDate.isValid() || expirationDate.isBefore(dayjs())) {
       localStorage.removeItem('accessToken');
       localStorage.removeItem('expiration');
-      return {};
+      return initialState;
     }
 
     return {
+      ...initialState,
       application: {
+        ...getApplication(initialState),
         authorization: {
+          ...getAuthorization(initialState),
           accessToken: JSON.parse(accessToken),
           expiration: expirationDate
         }
       }
     };
   } catch {
-    return {};
+    return initialState;
   }
 };

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -5,6 +5,7 @@ import {
   buildUrl,
   getInitialState
 } from './index';
+import { initialState } from 'reducers';
 
 describe('utilities', () => {
   it('can buildActions', () => {
@@ -95,7 +96,7 @@ describe('utilities', () => {
         }
       });
 
-      expect(getInitialState()).toEqual({
+      expect(getInitialState()).toMatchObject({
         application: {
           authorization: {
             accessToken,
@@ -108,7 +109,7 @@ describe('utilities', () => {
     it('returns an empty object if no data found', () => {
       localStorage.getItem.mockReturnValue(null);
 
-      expect(getInitialState()).toEqual({});
+      expect(getInitialState()).toEqual(initialState);
     });
 
     it('returns an empty object if token is expired', () => {
@@ -122,13 +123,13 @@ describe('utilities', () => {
         }
       });
 
-      expect(getInitialState()).toEqual({});
+      expect(getInitialState()).toEqual(initialState);
     });
 
     it('returns an empty object if an error occurs', () => {
       localStorage.getItem.mockReturnValue('baddate');
 
-      expect(getInitialState()).toEqual({});
+      expect(getInitialState()).toEqual(initialState);
     });
   });
 });


### PR DESCRIPTION
* [Changes](https://github.com/gusta-project/frontend/compare/master...ayan4m1:feature/fetch-current-user?expand=1#diff-d25ba671e0b49dde38d045baa368a1e5L112) the loginUserWorker flow. Now we only request a token if one is needed and only request the current user if one does not exist in the store. This means that `loginUserSuccess` always fires at the end of loginUserWorker and the toast is only shown once.
* [Fixed](https://github.com/gusta-project/frontend/compare/master...ayan4m1:feature/fetch-current-user?expand=1#diff-d25ba671e0b49dde38d045baa368a1e5R73) the route used to get current user info
* [Use](https://github.com/gusta-project/frontend/compare/master...ayan4m1:feature/fetch-current-user?expand=1#diff-bb7a6a61e449a99e756724ffa2c8c109R62) parameter destructuring on the requestTokenSuccess action creator
* [Export](https://github.com/gusta-project/frontend/compare/master...ayan4m1:feature/fetch-current-user?expand=1#diff-cfba9c145ca5d713b626b9c58bb518a7R8) one object which will contain the entire tree of initialState such that the store can be initialized using it
* [Return](https://github.com/gusta-project/frontend/compare/master...ayan4m1:feature/fetch-current-user?expand=1#diff-c561400e3720be1a9b2fea5e84ff802fR8) loggingIn and loggingOut as boolean from related selectors
* [Use](https://github.com/gusta-project/frontend/compare/master...ayan4m1:feature/fetch-current-user?expand=1#diff-8968c62593320351ced6a0ef776ef599R74) the newly-exported initialState to fully initialize the redux store - this is a require and not an import because trying to import it causes a circular dependency