### PR TITLE
Add VS Code debugging configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:9000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {


### PR DESCRIPTION
This PR adds a file that allows VS Code with the `msjsdiag.debugger-for-chrome` extension installed to do breakpoint debugging using Chrome's remote debugging feature.

To use it, just start the app using `npm start` as norma. Then, in VS Code, hit F5 or hit Ctrl-Shift-P and look for "Debug> Start Debugging". Select "Chrome" in the resulting dialog. A new instance of Chrome will open pointing at `localhost:9000`. From there you can set breakpoints and debug from VS Code per usual.