### PR TITLE
Refactoring Sass variables & stylelint warning fix

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -7,7 +7,11 @@ $baby-blue: #00bad3;
 $lighter-red: #ffccbc;
 $shadow-grey: #777;
 
-$sm: 576px;
-$md: 768px;
-$lg: 992px;
-$xl: 1200px;
+$min-sm: 576px;
+$max-sm: 575px;
+$min-md: 768px;
+$max-md: 767px;
+$min-lg: 992px;
+$max-lg: 991px;
+$min-xl: 1200px;
+$max-xl: 1199px;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -7,11 +7,16 @@ $baby-blue: #00bad3;
 $lighter-red: #ffccbc;
 $shadow-grey: #777;
 
+$min-xs: 0;
+$max-xs: 575px;
+
 $min-sm: 576px;
-$max-sm: 575px;
+$max-sm: 767px;
+
 $min-md: 768px;
-$max-md: 767px;
+$max-md: 991px;
+
 $min-lg: 992px;
-$max-lg: 991px;
+$max-lg: 1199px;
+
 $min-xl: 1200px;
-$max-xl: 1199px;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,0 +1,8 @@
+$lightest-blue: #e7f0ff;
+$lighter-blue: #d3e3fc;
+$light-blue: #b1cefd;
+$blue: #77a6f7;
+$teal: #00887a;
+$baby-blue: #00bad3;
+$lighter-red: #ffccbc;
+$shadow-grey: #777;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -6,3 +6,8 @@ $teal: #00887a;
 $baby-blue: #00bad3;
 $lighter-red: #ffccbc;
 $shadow-grey: #777;
+
+$sm: 576px;
+$md: 768px;
+$lg: 992px;
+$xl: 1200px;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -20,3 +20,33 @@ $min-lg: 992px;
 $max-lg: 1199px;
 
 $min-xl: 1200px;
+
+@mixin breakpoint-xs() {
+  @media (min-width: $min-xs) and (max-width: $max-xs) {
+    @content;
+  }
+}
+
+@mixin breakpoint-sm() {
+  @media (min-width: $min-sm) and (max-width: $max-sm) {
+    @content;
+  }
+}
+
+@mixin breakpoint-md() {
+  @media (min-width: $min-md) and (max-width: $max-md) {
+    @content;
+  }
+}
+
+@mixin breakpoint-lg() {
+  @media (min-width: $min-lg) and (max-width: $max-lg) {
+    @content;
+  }
+}
+
+@mixin breakpoint-xl() {
+  @media (min-width: $min-xl) {
+    @content;
+  }
+}

--- a/src/style.scss
+++ b/src/style.scss
@@ -49,13 +49,13 @@ hr {
 // it changes the width of the container and the width of the other elements around it
 // Switching the container to "fluid" didn't fix it, so this was unfortunately the best way I could
 // find to solve the issue; by fixing the container width for medium screens and up
-@media (min-width: $min-md) and (max-width: $max-lg) {
+@media (min-width: $min-md) and (max-width: $max-md) {
   .container {
     width: 800px;
   }
 }
 
-@media (min-width: $min-lg) and (max-width: $max-xl) {
+@media (min-width: $min-lg) and (max-width: $max-lg) {
   .container {
     width: 1000px;
   }
@@ -122,7 +122,7 @@ hr {
 }
 
 // Centering nav contents for phone screens
-@media (max-width: $max-lg) {
+@media (max-width: $max-md) {
   .navbar {
     justify-content: center;
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -157,7 +157,7 @@ hr {
   border: 1px solid $black;
 
   // Style for "striped" tables
-  .table-striped tbody tr:nth-of-type(odd) {
+  tr:nth-of-type(odd) .table-striped {
     background-color: $lightest-blue;
   }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -49,19 +49,19 @@ hr {
 // it changes the width of the container and the width of the other elements around it
 // Switching the container to "fluid" didn't fix it, so this was unfortunately the best way I could
 // find to solve the issue; by fixing the container width for medium screens and up
-@media (min-width: 768px) and (max-width: 991px) {
+@media (min-width: $md) and (max-width: $lg) {
   .container {
     width: 800px;
   }
 }
 
-@media (min-width: 992px) and (max-width: 1199px) {
+@media (min-width: $lg) and (max-width: $xl) {
   .container {
     width: 1000px;
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: $xl) {
   .container {
     width: 1200px;
   }
@@ -122,7 +122,7 @@ hr {
 }
 
 // Centering nav contents for phone screens
-@media (max-width: 700px) {
+@media (max-width: $lg) {
   .navbar {
     justify-content: center;
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -49,19 +49,19 @@ hr {
 // it changes the width of the container and the width of the other elements around it
 // Switching the container to "fluid" didn't fix it, so this was unfortunately the best way I could
 // find to solve the issue; by fixing the container width for medium screens and up
-@media (min-width: $md) and (max-width: calc($lg - 1)) {
+@media (min-width: $min-md) and (max-width: $max-lg) {
   .container {
     width: 800px;
   }
 }
 
-@media (min-width: $lg) and (max-width: calc($xl - 1)) {
+@media (min-width: $min-lg) and (max-width: $max-xl) {
   .container {
     width: 1000px;
   }
 }
 
-@media (min-width: $xl) {
+@media (min-width: $min-xl) {
   .container {
     width: 1200px;
   }
@@ -122,7 +122,7 @@ hr {
 }
 
 // Centering nav contents for phone screens
-@media (max-width: calc($lg - 1)) {
+@media (max-width: $max-lg) {
   .navbar {
     justify-content: center;
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,13 +1,5 @@
 @import url("https://fonts.googleapis.com/css?family=Architects+Daughter|Quicksand&display=swap");
-
-$lightest-blue: #e7f0ff;
-$lighter-blue: #d3e3fc;
-$light-blue: #b1cefd;
-$blue: #77a6f7;
-$teal: #00887a;
-$baby-blue: #00bad3;
-$lighter-red: #ffccbc;
-$shadow-grey: #777;
+@import "./_variables.scss";
 
 // Changes the font site-wide
 * {

--- a/src/style.scss
+++ b/src/style.scss
@@ -49,19 +49,19 @@ hr {
 // it changes the width of the container and the width of the other elements around it
 // Switching the container to "fluid" didn't fix it, so this was unfortunately the best way I could
 // find to solve the issue; by fixing the container width for medium screens and up
-@media (min-width: $min-md) and (max-width: $max-md) {
+@include breakpoint-md() {
   .container {
     width: 800px;
   }
 }
 
-@media (min-width: $min-lg) and (max-width: $max-lg) {
+@include breakpoint-lg() {
   .container {
     width: 1000px;
   }
 }
 
-@media (min-width: $min-xl) {
+@include breakpoint-xl() {
   .container {
     width: 1200px;
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -49,13 +49,13 @@ hr {
 // it changes the width of the container and the width of the other elements around it
 // Switching the container to "fluid" didn't fix it, so this was unfortunately the best way I could
 // find to solve the issue; by fixing the container width for medium screens and up
-@media (min-width: $md) and (max-width: $lg) {
+@media (min-width: $md) and (max-width: calc($lg - 1)) {
   .container {
     width: 800px;
   }
 }
 
-@media (min-width: $lg) and (max-width: $xl) {
+@media (min-width: $lg) and (max-width: calc($xl - 1)) {
   .container {
     width: 1000px;
   }
@@ -122,7 +122,7 @@ hr {
 }
 
 // Centering nav contents for phone screens
-@media (max-width: $lg) {
+@media (max-width: calc($lg - 1)) {
   .navbar {
     justify-content: center;
   }


### PR DESCRIPTION
https://github.com/gusta-project/frontend/commit/d765c2be0d39d0c885c5eb7534ff1f7e92b0a0a1 Moved the color variables to a new `_variables.scss` file, and imported back into `style.scss`.

https://github.com/gusta-project/frontend/commit/4e7c3f41b85128bd4f26fe3dad98b49d770b1a76 Added breakpoint sizes to `_variables.scss` and changed all breakpoints in `style.scss` to use these new variables.

https://github.com/gusta-project/frontend/commit/297908259212446e738bfc2d7dc9b2ab571f1bf2 Fixed the selectors for striped tables to make stylelint happy. There are now no longer any warnings from stylelint 🎉 .