### PR TITLE
Add fontawesome icon mock

### DIFF
--- a/src/__mocks__/@fortawesome/react-fontawesome.js
+++ b/src/__mocks__/@fortawesome/react-fontawesome.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export function FontAwesomeIcon({ icon }) {
+  const iconClass = Array.isArray(icon) ? icon.join('-') : icon;
+
+  return <i className={`fa ${iconClass}`} />;
+}
+
+FontAwesomeIcon.propTypes = {
+  icon: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      prefix: PropTypes.string,
+      iconName: PropTypes.string,
+      icon: PropTypes.arrayOf(PropTypes.any)
+    })
+  ]).isRequired
+};


### PR DESCRIPTION
This PR adds a mock for `@fortawesome/react-fontawesome` so that tests using `FontAwesomeIcon` do not need to snapshot the entire SVG icon.

It will render in the snapshot like

`<i class="fa far-heart" />`