### PR TITLE
Make prop-type warnings during test execution cause test failures

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/*.js'],
   coverageDirectory: './coverage',
   coverageReporters: ['html', 'text-summary', 'lcov'],
-  setupFiles: ['jest-localstorage-mock'],
+  setupFiles: ['jest-localstorage-mock', 'jest-prop-type-error'],
   modulePaths: ['<rootDir>/src/'],
   globals: {
     API_URL: 'http://localhost:3000'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10428,6 +10428,12 @@
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
       "dev": true
     },
+    "jest-prop-type-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jest-prop-type-error/-/jest-prop-type-error-1.1.0.tgz",
+      "integrity": "sha512-i/4hdbKSp6cFJc2z3Blu2WEOGjxbQ76pShhtDFIqUfdC8ruMGT57EOsBtBq69FVg915MUMwENNc185ejs7mmtg==",
+      "dev": true
+    },
     "jest-regex-util": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "jest": "^24.8.0",
     "jest-localstorage-mock": "^2.4.0",
     "jest-mock-axios": "^3.0.0",
+    "jest-prop-type-error": "^1.1.0",
     "lint-staged": "^9.2.0",
     "mini-css-extract-plugin": "^0.8.0",
     "mockdate": "^2.0.3",


### PR DESCRIPTION
This PR adds [jest-prop-type-error](https://www.npmjs.com/package/jest-prop-type-error), which is added as a `setupFile` in the Jest configuration and will make any prop-type warnings cause a Jest test responsible for them to fail.