### PR TITLE
core-js v3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,23 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "usage",
+        "corejs": 3
+      }
+    ],
+    "@babel/preset-react"
+  ],
   "plugins": [
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-object-rest-spread",
-    "@babel/plugin-transform-runtime",
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        "corejs": 3
+      }
+    ],
     "@babel/plugin-transform-regenerator"
   ]
 }

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,1 @@
-last 2 versions
-not dead
-> 1%
+last 2 versions and not dead and > 1%

--- a/package-lock.json
+++ b/package-lock.json
@@ -977,6 +977,15 @@
         "regenerator-runtime": "^0.13.2"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.5.5.tgz",
+      "integrity": "sha512-bNxHJ+w7RfLzZJtIZdEjFgL1twwZ6ozuOmsEjtyuTqfi1hb1fqsDYYyi3Fi3i+RgAO4S9+wkSG102+GCqdpr7w==",
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -5112,8 +5121,7 @@
     "core-js-pure": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
-      "dev": true
+      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "analyze:bundle": "cross-env NODE_ENV=production ANALYZE_BUNDLE=true webpack"
   },
   "dependencies": {
-    "@babel/runtime": "^7.5.5",
+    "@babel/runtime-corejs3": "^7.5.5",
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-regular-svg-icons": "^5.10.2",
     "@fortawesome/free-solid-svg-icons": "^5.10.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,3 @@
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
This PR updates our babel toolchain to use the latest version of core-js. [This document](https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md) contains a lot of info about how and why to upgrade.

* [Configure](https://github.com/gusta-project/frontend/pull/42/files#diff-e56633f72ecc521128b3db6586074d2cR2) Babel to use core-js 3 in "usage" mode
* [Stop](https://github.com/gusta-project/frontend/pull/42/files#diff-7f5f3113150dddb0b76c2a8714a14e00R1) supporting some esoteric browsers
* [Remove](https://github.com/gusta-project/frontend/pull/42/files#diff-1fdf421c05c1140f6d71444ea2b27638L1) the now-unnecessary polyfill imports from index.js